### PR TITLE
Get rid of nap with gopeek

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,7 +1,21 @@
-hash: 1a0062ef2d587d01d6f576a71957f65375c8bb6e241175c9568a1bb78e75e961
-updated: 2016-09-15T11:05:34.222002397-07:00
-imports: []
+hash: c7cd958e26264a16871379d6552c8c91064569141ee09026cb57461a06517d32
+updated: 2016-12-11T02:20:35.223545802Z
+imports:
+- name: github.com/cat2neat/gopeek
+  version: aa9fedf5c8c91f2e882c342a8388de958e21a210
+- name: github.com/maruel/panicparse
+  version: ad661195ed0e88491e0f14be6613304e3b1141d6
+  subpackages:
+  - stack
 testImports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/stretchr/testify
   version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,3 +5,4 @@ testImport:
   subpackages:
   - assert
 - package: github.com/uber-go/atomic
+- package: github.com/cat2neat/gopeek

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -129,7 +129,8 @@ func TestDelayedRateLimiter(t *testing.T) {
 	})
 
 	clock.AfterFunc(30*time.Second, func() {
-		assert.InDelta(t, 1200, count.Load(), 10, "count within rate limit")
+		// 11 is more accurate as a slow job also may count up before this func.
+		assert.InDelta(t, 1200, count.Load(), 11, "count within rate limit")
 		wg.Done()
 	})
 

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -137,7 +137,7 @@ func TestDelayedRateLimiter(t *testing.T) {
 	condition := gopeek.NewCondition().
 		CreatedBy("ratelimit_test.TestDelayedRateLimiter").
 		Is(gopeek.StateWaitingChannel).
-		// go ahead when there is >= 1 waiting channel via Mock.Sleep
+		// go ahead when there is > 0 waiting channel via Mock.Sleep
 		// as it's evidence that ratelimit occurred
 		GT(0)
 	clock.Add(40*time.Second, condition)


### PR DESCRIPTION
The below is quoted from https://github.com/uber-go/ratelimit/pull/1#discussion-diff-78767601 .

> Alternatively, if this is purely for testing, we could have a "sleep till there's no runnable goroutines" function. There's no easy way to do it, but we'd get a list of all goroutines, and make sure that they're all blocked on something.

As I felt there are not negligible such needs especially for testing
I've developed https://github.com/cat2neat/gopeek to realise the above requirements in a generalized way.

This PR would
- get rid of nap with gopeek
- get the test time speed up around 3times.
- get the test more stable in a resource constrained one like travis-ci as time.Sleep tend to be unstable