### PR TITLE
Update the Limiter interface to accept a context.Context object

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,18 @@
 hash: 1a0062ef2d587d01d6f576a71957f65375c8bb6e241175c9568a1bb78e75e961
-updated: 2016-09-15T11:05:34.222002397-07:00
+updated: 2017-10-04T21:35:24.107303757-07:00
 imports: []
 testImports:
+- name: github.com/davecgh/go-spew
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
   subpackages:
   - assert
 - name: github.com/uber-go/atomic
-  version: 0c9e689d64f004564b79d9a663634756df322902
+  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -102,7 +102,9 @@ func (t *limiter) Take(ctx context.Context) bool {
 
 	// If sleepFor is positive, then we should sleep now.
 	if t.sleepFor > 0 {
-		t.timer.Stop()
+		if !t.timer.Stop() {
+			<-t.timer.C
+		}
 		t.timer.Reset(t.sleepFor)
 		select {
 		case <-t.timer.C:

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -80,8 +80,6 @@ func TestRateLimiter(t *testing.T) {
 		assert.InDelta(t, 300, count.Load(), 10, "count within rate limit")
 		wg.Done()
 	})
-
-	<-time.NewTimer(10 * time.Second).C
 }
 
 func TestDelayedRateLimiter(t *testing.T) {


### PR DESCRIPTION
This also removes the Clock abstraction, since there doesn't seem to be a way to create timers using the mock clock effectively, and it isn't used in yab at all. I can add it back in and try to munge it to work if it has value.