### PR TITLE
Atomic based limiter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 test:
-	go test .
+	go test -race .
 cover:
 	go test . -coverprofile=cover.out
 	go tool cover -html=cover.out
+bench:
+	go test -bench=.

--- a/mutexbased.go
+++ b/mutexbased.go
@@ -16,7 +16,7 @@ type mutexLimiter struct {
 }
 
 // New returns a Limiter that will limit to the given RPS.
-func NewMutexBased(rate int, opts ...Option) Limiter {
+func newMutexBased(rate int, opts ...Option) Limiter {
 	l := &mutexLimiter{
 		perRequest: time.Second / time.Duration(rate),
 		maxSlack:   -10 * time.Second / time.Duration(rate),

--- a/mutexbased.go
+++ b/mutexbased.go
@@ -1,0 +1,67 @@
+package ratelimit
+
+import (
+	"go.uber.org/ratelimit/internal/clock"
+	"sync"
+	"time"
+)
+
+type mutexLimiter struct {
+	sync.Mutex
+	last       time.Time
+	sleepFor   time.Duration
+	perRequest time.Duration
+	maxSlack   time.Duration
+	clock      Clock
+}
+
+// New returns a Limiter that will limit to the given RPS.
+func NewMutexBased(rate int, opts ...Option) Limiter {
+	l := &mutexLimiter{
+		perRequest: time.Second / time.Duration(rate),
+		maxSlack:   -10 * time.Second / time.Duration(rate),
+	}
+	if l.clock == nil {
+		l.clock = clock.New()
+	}
+	return l
+}
+
+// Take blocks to ensure that the time spent between multiple
+// Take calls is on average time.Second/rate.
+func (t *mutexLimiter) Take() time.Time {
+	t.Lock()
+	defer t.Unlock()
+
+	now := t.clock.Now()
+
+	// If this is our first request, then we allow it.
+	if t.last.IsZero() {
+		t.last = now
+		return t.last
+	}
+
+	// sleepFor calculates how much time we should sleep based on
+	// the perRequest budget and how long the last request took.
+	// Since the request may take longer than the budget, this number
+	// can get negative, and is summed across requests.
+	t.sleepFor += t.perRequest - now.Sub(t.last)
+
+	// We shouldn't allow sleepFor to get too negative, since it would mean that
+	// a service that slowed down a lot for a short period of time would get
+	// a much higher RPS following that.
+	if t.sleepFor < t.maxSlack {
+		t.sleepFor = t.maxSlack
+	}
+
+	// If sleepFor is positive, then we should sleep now.
+	if t.sleepFor > 0 {
+		t.clock.Sleep(t.sleepFor)
+		t.last = now.Add(t.sleepFor)
+		t.sleepFor = 0
+	} else {
+		t.last = now
+	}
+
+	return t.last
+}

--- a/ratelimit_bench_test.go
+++ b/ratelimit_bench_test.go
@@ -1,0 +1,88 @@
+package ratelimit
+
+import (
+	"fmt"
+	"github.com/uber-go/atomic"
+	"go.uber.org/ratelimit"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func BenchmarkRateLimiter(b *testing.B) {
+	count := atomic.NewInt64(0)
+	for _, procs := range []int{1, 4, 8, 16} {
+		runtime.GOMAXPROCS(procs)
+		for name, limiter := range map[string]ratelimit.Limiter{
+			"atomic": New(b.N * 10000000),
+			"mutex":  NewMutexBased(b.N * 10000000),
+		} {
+			for ng := 1; ng < 16; ng += 1 {
+				runner(b, name, procs, ng, limiter, count)
+			}
+			for ng := 16; ng < 128; ng += 8 {
+				runner(b, name, procs, ng, limiter, count)
+			}
+			for ng := 128; ng < 512; ng += 16 {
+				runner(b, name, procs, ng, limiter, count)
+			}
+			for ng := 512; ng < 1024; ng += 32 {
+				runner(b, name, procs, ng, limiter, count)
+			}
+			for ng := 1024; ng < 2048; ng += 8 {
+				runner(b, name, procs, ng, limiter, count)
+			}
+			for ng := 2048; ng < 4096; ng += 128 {
+				runner(b, name, procs, ng, limiter, count)
+			}
+			for ng := 4096; ng < 16384; ng += 512 {
+				runner(b, name, procs, ng, limiter, count)
+			}
+			for ng := 16384; ng < 65536; ng += 2048 {
+				runner(b, name, procs, ng, limiter, count)
+			}
+		}
+	}
+	fmt.Printf("\nmark%d\n", count.Load())
+}
+
+func runner(b *testing.B, name string, procs int, ng int, limiter Limiter, count *atomic.Int64) bool {
+	return b.Run(fmt.Sprintf("type:%s-procs:%d-goroutines:%d", name, procs, ng), func(b *testing.B) {
+		var wg sync.WaitGroup
+		trigger := atomic.NewBool(true)
+		n := b.N
+		batchSize := n / ng
+		if batchSize == 0 {
+			batchSize = n
+		}
+		for n > 0 {
+			wg.Add(1)
+			batch := min(n, batchSize)
+			n -= batch
+			go func(quota int) {
+				for trigger.Load() {
+					runtime.Gosched()
+				}
+				localCnt := 0
+				for i := 0; i < quota; i++ {
+					res := limiter.Take()
+					localCnt += res.Nanosecond()
+				}
+				count.Add(int64(localCnt))
+				wg.Done()
+			}(batch)
+		}
+
+		b.StartTimer()
+		trigger.Store(false)
+		wg.Wait()
+		b.StopTimer()
+	})
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/ratelimit_bench_test.go
+++ b/ratelimit_bench_test.go
@@ -3,7 +3,6 @@ package ratelimit
 import (
 	"fmt"
 	"github.com/uber-go/atomic"
-	"go.uber.org/ratelimit"
 	"runtime"
 	"sync"
 	"testing"
@@ -13,9 +12,9 @@ func BenchmarkRateLimiter(b *testing.B) {
 	count := atomic.NewInt64(0)
 	for _, procs := range []int{1, 4, 8, 16} {
 		runtime.GOMAXPROCS(procs)
-		for name, limiter := range map[string]ratelimit.Limiter{
+		for name, limiter := range map[string]Limiter{
 			"atomic": New(b.N * 10000000),
-			"mutex":  NewMutexBased(b.N * 10000000),
+			"mutex":  newMutexBased(b.N * 10000000),
 		} {
 			for ng := 1; ng < 16; ng += 1 {
 				runner(b, name, procs, ng, limiter, count)


### PR DESCRIPTION
Hi,
I've made your limiter implementation atomic based. It is a little bit harder but in generally faster and has no goroutine scalability issues that any mutex based implementation have.
Checkout this relation between RateLimiter latency and count of goroutines:
<img width="993" alt="limiter_scalability" src="https://user-images.githubusercontent.com/3532750/47335602-aa920400-d694-11e8-8eaa-a95e980e3024.png">
Original implementation moved to mutexbased.go file, so you can run benchmarks and play with other tests. But I'd suggest to leave only one implementation after all.

[Side note] This wired latency spike in mutex based implementation is a direct illustration of mutex falling into [starvation mode](https://github.com/golang/go/blob/master/src/sync/mutex.go#L44).

Full benchmarking results [here](https://github.com/uber-go/ratelimit/files/2504561/full_test_with_procs_fit.pdf)
