### PR TITLE
Fix `go vet` warning about bad Example naming

### DIFF
--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func ExampleRatelimit() {
+func Example() {
 	rl := ratelimit.New(100) // per second
 
 	prev := time.Now()
@@ -80,8 +80,6 @@ func TestRateLimiter(t *testing.T) {
 	})
 
 	clock.Add(4 * time.Second)
-
-	clock.Add(5 * time.Second)
 }
 
 func TestDelayedRateLimiter(t *testing.T) {


### PR DESCRIPTION
See https://golang.org/pkg/testing/#hdr-Examples.

It could be `Example` or `ExampleLimiter` or `ExampleLimiter_Take`
but given we have a single Example example should be good enough.

Also removes an unnecessary `clock.Add` in a test.