### PR TITLE
Move alternative implementations to internal/alternatives/*

### DIFF
--- a/internal/alternatives/atomic/limiter.go
+++ b/internal/alternatives/atomic/limiter.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2016, 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package atomic
+
+import (
+	"time"
+
+	"sync/atomic"
+	"unsafe"
+
+	"go.uber.org/ratelimit/internal/clock"
+)
+
+// Note: This file is inspired by:
+// https://github.com/prashantv/go-bench/blob/master/ratelimit
+
+type state struct {
+	last     time.Time
+	sleepFor time.Duration
+}
+
+type limiter struct {
+	state unsafe.Pointer
+	//lint:ignore U1000 Padding is unused but it is crucial to maintain performance
+	// of this rate limiter in case of collocation with other frequently accessed memory.
+	padding [56]byte // cache line size - state pointer size = 64 - 8; created to avoid false sharing.
+
+	perRequest time.Duration
+	maxSlack   time.Duration
+	clock      clock.Clock
+}
+
+// Option configures a Limiter.
+type Option func(l *limiter)
+
+// New returns a Limiter that will limit to the given RPS.
+func New(rate int, opts ...Option) *limiter {
+	l := &limiter{
+		perRequest: time.Second / time.Duration(rate),
+		maxSlack:   -10 * time.Second / time.Duration(rate),
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	if l.clock == nil {
+		l.clock = clock.New()
+	}
+	initialState := state{
+		last:     time.Time{},
+		sleepFor: 0,
+	}
+	atomic.StorePointer(&l.state, unsafe.Pointer(&initialState))
+	return l
+}
+
+// WithClock returns an option for ratelimit.New that provides an alternate
+// Clock implementation, typically a mock Clock for testing.
+func WithClock(clock clock.Clock) Option {
+	return func(l *limiter) {
+		l.clock = clock
+	}
+}
+
+// WithoutSlack is an option for ratelimit.New that initializes the limiter
+// without any initial tolerance for bursts of traffic.
+var WithoutSlack Option = withoutSlackOption
+
+func withoutSlackOption(l *limiter) {
+	l.maxSlack = 0
+}
+
+// Take blocks to ensure that the time spent between multiple
+// Take calls is on average time.Second/rate.
+func (t *limiter) Take() time.Time {
+	newState := state{}
+	taken := false
+	for !taken {
+		now := t.clock.Now()
+
+		previousStatePointer := atomic.LoadPointer(&t.state)
+		oldState := (*state)(previousStatePointer)
+
+		newState = state{}
+		newState.last = now
+
+		// If this is our first request, then we allow it.
+		if oldState.last.IsZero() {
+			taken = atomic.CompareAndSwapPointer(&t.state, previousStatePointer, unsafe.Pointer(&newState))
+			continue
+		}
+
+		// sleepFor calculates how much time we should sleep based on
+		// the perRequest budget and how long the last request took.
+		// Since the request may take longer than the budget, this number
+		// can get negative, and is summed across requests.
+		newState.sleepFor += t.perRequest - now.Sub(oldState.last)
+		// We shouldn't allow sleepFor to get too negative, since it would mean that
+		// a service that slowed down a lot for a short period of time would get
+		// a much higher RPS following that.
+		if newState.sleepFor < t.maxSlack {
+			newState.sleepFor = t.maxSlack
+		}
+		if newState.sleepFor > 0 {
+			newState.last = newState.last.Add(newState.sleepFor)
+		}
+		taken = atomic.CompareAndSwapPointer(&t.state, previousStatePointer, unsafe.Pointer(&newState))
+	}
+	t.clock.Sleep(newState.sleepFor)
+	return newState.last
+}

--- a/internal/alternatives/atomic/limiter_test.go
+++ b/internal/alternatives/atomic/limiter_test.go
@@ -1,0 +1,108 @@
+package atomic
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/atomic"
+	"go.uber.org/ratelimit/internal/clock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimiter(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer wg.Wait()
+
+	clock := clock.NewMock()
+	rl := New(100, WithClock(clock), WithoutSlack)
+
+	count := atomic.NewInt32(0)
+
+	// Until we're done...
+	done := make(chan struct{})
+	defer close(done)
+
+	// Create copious counts concurrently.
+	go job(rl, count, done)
+	go job(rl, count, done)
+	go job(rl, count, done)
+	go job(rl, count, done)
+
+	clock.AfterFunc(1*time.Second, func() {
+		assert.InDelta(t, 100, count.Load(), 10, "count within rate limit")
+	})
+
+	clock.AfterFunc(2*time.Second, func() {
+		assert.InDelta(t, 200, count.Load(), 10, "count within rate limit")
+	})
+
+	clock.AfterFunc(3*time.Second, func() {
+		assert.InDelta(t, 300, count.Load(), 10, "count within rate limit")
+		wg.Done()
+	})
+
+	clock.Add(4 * time.Second)
+
+	clock.Add(5 * time.Second)
+}
+
+func TestDelayedRateLimiter(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer wg.Wait()
+
+	clock := clock.NewMock()
+	slow := New(10, WithClock(clock))
+	fast := New(100, WithClock(clock))
+
+	count := atomic.NewInt32(0)
+
+	// Until we're done...
+	done := make(chan struct{})
+	defer close(done)
+
+	// Run a slow job
+	go func() {
+		for {
+			slow.Take()
+			fast.Take()
+			count.Inc()
+			select {
+			case <-done:
+				return
+			default:
+			}
+		}
+	}()
+
+	// Accumulate slack for 10 seconds,
+	clock.AfterFunc(20*time.Second, func() {
+		// Then start working.
+		go job(fast, count, done)
+		go job(fast, count, done)
+		go job(fast, count, done)
+		go job(fast, count, done)
+	})
+
+	clock.AfterFunc(30*time.Second, func() {
+		assert.InDelta(t, 1200, count.Load(), 10, "count within rate limit")
+		wg.Done()
+	})
+
+	clock.Add(40 * time.Second)
+}
+
+func job(rl *limiter, count *atomic.Int32, done <-chan struct{}) {
+	for {
+		rl.Take()
+		count.Inc()
+		select {
+		case <-done:
+			return
+		default:
+		}
+	}
+}

--- a/internal/alternatives/mutex/limiter.go
+++ b/internal/alternatives/mutex/limiter.go
@@ -1,23 +1,24 @@
-package ratelimit
+package mutex
 
 import (
-	"go.uber.org/ratelimit/internal/clock"
 	"sync"
 	"time"
+
+	"go.uber.org/ratelimit/internal/clock"
 )
 
-type mutexLimiter struct {
+type limiter struct {
 	sync.Mutex
 	last       time.Time
 	sleepFor   time.Duration
 	perRequest time.Duration
 	maxSlack   time.Duration
-	clock      Clock
+	clock      clock.Clock
 }
 
 // New returns a Limiter that will limit to the given RPS.
-func newMutexBased(rate int, opts ...Option) Limiter {
-	l := &mutexLimiter{
+func New(rate int) *limiter {
+	l := &limiter{
 		perRequest: time.Second / time.Duration(rate),
 		maxSlack:   -10 * time.Second / time.Duration(rate),
 	}
@@ -29,7 +30,7 @@ func newMutexBased(rate int, opts ...Option) Limiter {
 
 // Take blocks to ensure that the time spent between multiple
 // Take calls is on average time.Second/rate.
-func (t *mutexLimiter) Take() time.Time {
+func (t *limiter) Take() time.Time {
 	t.Lock()
 	defer t.Unlock()
 

--- a/internal/clock/clock.go
+++ b/internal/clock/clock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2016, 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -87,15 +87,13 @@ func (m *Mock) After(d time.Duration) <-chan time.Time {
 }
 
 // AfterFunc waits for the duration to elapse and then executes a function.
-// A Timer is returned that can be stopped.
-func (m *Mock) AfterFunc(d time.Duration, f func()) *Timer {
+func (m *Mock) AfterFunc(d time.Duration, f func()) {
 	t := m.Timer(d)
 	go func() {
 		<-t.c
 		f()
 	}()
 	nap()
-	return t
 }
 
 // Now returns the current wall time on the mock clock.

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2016, 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,10 +23,7 @@ package ratelimit // import "go.uber.org/ratelimit"
 import (
 	"time"
 
-	"sync/atomic"
-	"unsafe"
-
-	"go.uber.org/ratelimit/internal/clock"
+	"go.uber.org/ratelimit/internal/alternatives/atomic"
 )
 
 // Note: This file is inspired by:
@@ -48,108 +45,16 @@ type Clock interface {
 	Sleep(time.Duration)
 }
 
-type state struct {
-	last     time.Time
-	sleepFor time.Duration
-}
-
-type limiter struct {
-	state unsafe.Pointer
-	//lint:ignore U1000 Padding is unused but it is crucial to maintain performance
-	// of this rate limiter in case of collocation with other frequently accessed memory.
-	padding [56]byte // cache line size - state pointer size = 64 - 8; created to avoid false sharing.
-
-	perRequest time.Duration
-	maxSlack   time.Duration
-	clock      Clock
-}
-
 // Option configures a Limiter.
-type Option func(l *limiter)
+type Option = atomic.Option
 
-// New returns a Limiter that will limit to the given RPS.
-func New(rate int, opts ...Option) Limiter {
-	l := &limiter{
-		perRequest: time.Second / time.Duration(rate),
-		maxSlack:   -10 * time.Second / time.Duration(rate),
-	}
-	for _, opt := range opts {
-		opt(l)
-	}
-	if l.clock == nil {
-		l.clock = clock.New()
-	}
-	initialState := state{
-		last:     time.Time{},
-		sleepFor: 0,
-	}
-	atomic.StorePointer(&l.state, unsafe.Pointer(&initialState))
-	return l
-}
-
-// WithClock returns an option for ratelimit.New that provides an alternate
-// Clock implementation, typically a mock Clock for testing.
-func WithClock(clock Clock) Option {
-	return func(l *limiter) {
-		l.clock = clock
-	}
-}
-
-// WithoutSlack is an option for ratelimit.New that initializes the limiter
-// without any initial tolerance for bursts of traffic.
-var WithoutSlack Option = withoutSlackOption
-
-func withoutSlackOption(l *limiter) {
-	l.maxSlack = 0
-}
-
-// Take blocks to ensure that the time spent between multiple
-// Take calls is on average time.Second/rate.
-func (t *limiter) Take() time.Time {
-	newState := state{}
-	taken := false
-	for !taken {
-		now := t.clock.Now()
-
-		previousStatePointer := atomic.LoadPointer(&t.state)
-		oldState := (*state)(previousStatePointer)
-
-		newState = state{}
-		newState.last = now
-
-		// If this is our first request, then we allow it.
-		if oldState.last.IsZero() {
-			taken = atomic.CompareAndSwapPointer(&t.state, previousStatePointer, unsafe.Pointer(&newState))
-			continue
-		}
-
-		// sleepFor calculates how much time we should sleep based on
-		// the perRequest budget and how long the last request took.
-		// Since the request may take longer than the budget, this number
-		// can get negative, and is summed across requests.
-		newState.sleepFor += t.perRequest - now.Sub(oldState.last)
-		// We shouldn't allow sleepFor to get too negative, since it would mean that
-		// a service that slowed down a lot for a short period of time would get
-		// a much higher RPS following that.
-		if newState.sleepFor < t.maxSlack {
-			newState.sleepFor = t.maxSlack
-		}
-		if newState.sleepFor > 0 {
-			newState.last = newState.last.Add(newState.sleepFor)
-		}
-		taken = atomic.CompareAndSwapPointer(&t.state, previousStatePointer, unsafe.Pointer(&newState))
-	}
-	t.clock.Sleep(newState.sleepFor)
-	return newState.last
-}
-
-type unlimited struct{}
-
-// NewUnlimited returns a RateLimiter that is not limited.
-func NewUnlimited() Limiter {
-	return unlimited{}
-}
-
-func (unlimited) Take() time.Time {
-	return time.Now()
-}
+// We currently have multiple implementations of the rate-limiter - we plan
+// to do more testing & pick the best one (or give people an option to select
+// appropriate one). In the meantime, we're exposing a single limiter.
+var (
+	// New returns a Limiter that will limit to the given RPS.
+	New = atomic.New
+	// WithClock returns an option for ratelimit.New that provides an alternate
+	// Clock implementation, typically a mock Clock for testing.
+	WithClock = atomic.WithClock
+)

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -1,20 +1,12 @@
-package ratelimit_test
+package ratelimit
 
 import (
 	"fmt"
-	"sync"
-	"testing"
 	"time"
-
-	"go.uber.org/atomic"
-	"go.uber.org/ratelimit"
-	"go.uber.org/ratelimit/internal/clock"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func ExampleRatelimit() {
-	rl := ratelimit.New(100) // per second
+	rl := New(100) // per second
 
 	prev := time.Now()
 	for i := 0; i < 10; i++ {
@@ -35,109 +27,4 @@ func ExampleRatelimit() {
 	// 7 10ms
 	// 8 10ms
 	// 9 10ms
-}
-
-func TestUnlimited(t *testing.T) {
-	now := time.Now()
-	rl := ratelimit.NewUnlimited()
-	for i := 0; i < 1000; i++ {
-		rl.Take()
-	}
-	assert.Condition(t, func() bool { return time.Since(now) < 1*time.Millisecond }, "no artificial delay")
-}
-
-func TestRateLimiter(t *testing.T) {
-	var wg sync.WaitGroup
-	wg.Add(1)
-	defer wg.Wait()
-
-	clock := clock.NewMock()
-	rl := ratelimit.New(100, ratelimit.WithClock(clock), ratelimit.WithoutSlack)
-
-	count := atomic.NewInt32(0)
-
-	// Until we're done...
-	done := make(chan struct{})
-	defer close(done)
-
-	// Create copious counts concurrently.
-	go job(rl, count, done)
-	go job(rl, count, done)
-	go job(rl, count, done)
-	go job(rl, count, done)
-
-	clock.AfterFunc(1*time.Second, func() {
-		assert.InDelta(t, 100, count.Load(), 10, "count within rate limit")
-	})
-
-	clock.AfterFunc(2*time.Second, func() {
-		assert.InDelta(t, 200, count.Load(), 10, "count within rate limit")
-	})
-
-	clock.AfterFunc(3*time.Second, func() {
-		assert.InDelta(t, 300, count.Load(), 10, "count within rate limit")
-		wg.Done()
-	})
-
-	clock.Add(4 * time.Second)
-
-	clock.Add(5 * time.Second)
-}
-
-func TestDelayedRateLimiter(t *testing.T) {
-	var wg sync.WaitGroup
-	wg.Add(1)
-	defer wg.Wait()
-
-	clock := clock.NewMock()
-	slow := ratelimit.New(10, ratelimit.WithClock(clock))
-	fast := ratelimit.New(100, ratelimit.WithClock(clock))
-
-	count := atomic.NewInt32(0)
-
-	// Until we're done...
-	done := make(chan struct{})
-	defer close(done)
-
-	// Run a slow job
-	go func() {
-		for {
-			slow.Take()
-			fast.Take()
-			count.Inc()
-			select {
-			case <-done:
-				return
-			default:
-			}
-		}
-	}()
-
-	// Accumulate slack for 10 seconds,
-	clock.AfterFunc(20*time.Second, func() {
-		// Then start working.
-		go job(fast, count, done)
-		go job(fast, count, done)
-		go job(fast, count, done)
-		go job(fast, count, done)
-	})
-
-	clock.AfterFunc(30*time.Second, func() {
-		assert.InDelta(t, 1200, count.Load(), 10, "count within rate limit")
-		wg.Done()
-	})
-
-	clock.Add(40 * time.Second)
-}
-
-func job(rl ratelimit.Limiter, count *atomic.Int32, done <-chan struct{}) {
-	for {
-		rl.Take()
-		count.Inc()
-		select {
-		case <-done:
-			return
-		default:
-		}
-	}
 }


### PR DESCRIPTION
We currently have two different implementations. Currently:
- they're in the same package
- one of them is currently not tested
- one has a bug related to slack (see #27, #23)
- one has a broken constructor taking options affecting the other type

We plan to add at least 3 more implementations:
- one that addresses #22
- one that re-uses ratelimitfx atomic style
- one that compares us against x/time/rate

Even if we decide to eventually keep a single implementation,
they'll be there for a while. And I imagine it'll get noisy.

(A crazy idea would be to return different implementation based on
some user params. But that's totally TBD).

This diff tries to organize us a bit my moving the separate
implementations to separate packages.

Followups:
- will try to refactor the tests into a shared test package & re-use them.
  This way we can write tests once and make sure new implementations
  are working as expected.
- will try to make sure the implementations take equivalent
  configuration
- will have to modify the root ratelimit package to have stronger
  type guarantees, and not just aliasing methods - that would require
  a separate /types package though (I think).

Accidentally this diff is also changing signature of AfterFunc
in internal/clock package. This is so that it implements
it's own Clock interface. It's a bit of a temporary hack
as well - #3 will make it a bit simpler.