### PR TITLE
Prefactor types into a separarate types package

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016, 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import "time"
+
+// Limiter is used to rate-limit some process, possibly across goroutines.
+// The process is expected to call Take() before every iteration, which
+// may block to throttle the goroutine.
+type Limiter interface {
+	// Take should block to make sure that the RPS is met.
+	Take() time.Time
+}
+
+// Clock is the minimum necessary interface to instantiate a rate limiter with
+// a clock or mock clock, compatible with clocks created using
+// github.com/andres-erbsen/clock.
+type Clock interface {
+	Now() time.Time
+	Sleep(time.Duration)
+}

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -27,6 +27,7 @@ import (
 	"unsafe"
 
 	"go.uber.org/ratelimit/internal/clock"
+	"go.uber.org/ratelimit/internal/types"
 )
 
 // Note: This file is inspired by:
@@ -35,18 +36,12 @@ import (
 // Limiter is used to rate-limit some process, possibly across goroutines.
 // The process is expected to call Take() before every iteration, which
 // may block to throttle the goroutine.
-type Limiter interface {
-	// Take should block to make sure that the RPS is met.
-	Take() time.Time
-}
+type Limiter = types.Limiter
 
 // Clock is the minimum necessary interface to instantiate a rate limiter with
 // a clock or mock clock, compatible with clocks created using
 // github.com/andres-erbsen/clock.
-type Clock interface {
-	Now() time.Time
-	Sleep(time.Duration)
-}
+type Clock = types.Clock
 
 type state struct {
 	last     time.Time


### PR DESCRIPTION
This came up in #37 where we ended up in a dependency loop.
- main package was importing a specific rate limiter type
- both rate limiters needed to import Clock types from main package

By moving it to a separate package we avoid that loop.

If we decide to go ahead with #37, this will also be necessary
to have a "common config type" that can be re-used between all N
alternative limiters.