### PR TITLE
Provide a way to be able to configure multiple Limiters with same options

### DIFF
--- a/mutexbased.go
+++ b/mutexbased.go
@@ -1,7 +1,6 @@
 package ratelimit
 
 import (
-	"go.uber.org/ratelimit/internal/clock"
 	"sync"
 	"time"
 )
@@ -16,13 +15,12 @@ type mutexLimiter struct {
 }
 
 // New returns a Limiter that will limit to the given RPS.
-func newMutexBased(rate int, opts ...Option) Limiter {
+func newMutexBased(rate int, opts ...option) Limiter {
+	config := buildConfig(opts)
 	l := &mutexLimiter{
 		perRequest: time.Second / time.Duration(rate),
-		maxSlack:   -10 * time.Second / time.Duration(rate),
-	}
-	if l.clock == nil {
-		l.clock = clock.New()
+		maxSlack:   -1 * config.maxSlack * time.Second / time.Duration(rate),
+		clock:      config.clock,
 	}
 	return l
 }


### PR DESCRIPTION
…ions

This is a bit of yack-shaving
- the atomic limiter has a bug - it ignores slack.
- I'd like to add it as a test
- but before doing that, I'd like to have the tests run the same
  on both limiters - to keep them in sync
- to do that, I need be able to configure them in the same way.

Currently. it's a bit of a mess:
- both limiters take Option, but mutexbased simply ignores them
  (because Option only works for the atomic one)

The only way I see to do that stably is to introduce a new stuct
to capture the configuration, and then have each limiter configure
itself based on that struct.

Contrary to the usual setup, having it as a struct should be future
proof - it's an internal struct, so we can change it later on.