### PR TITLE
Rename option to Option

### DIFF
--- a/mutexbased.go
+++ b/mutexbased.go
@@ -15,7 +15,7 @@ type mutexLimiter struct {
 }
 
 // New returns a Limiter that will limit to the given RPS.
-func newMutexBased(rate int, opts ...option) Limiter {
+func newMutexBased(rate int, opts ...Option) Limiter {
 	config := buildConfig(opts)
 	l := &mutexLimiter{
 		perRequest: time.Second / time.Duration(rate),

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -71,7 +71,7 @@ type config struct {
 }
 
 // buildConfig combines defaults with options.
-func buildConfig(opts []option) config {
+func buildConfig(opts []Option) config {
 	c := config{
 		maxSlack: 10,
 		clock:    clock.New(),
@@ -83,11 +83,11 @@ func buildConfig(opts []option) config {
 	return c
 }
 
-// option configures a Limiter.
-type option func(l *config)
+// Option configures a Limiter.
+type Option func(l *config)
 
 // New returns a Limiter that will limit to the given RPS.
-func New(rate int, opts ...option) Limiter {
+func New(rate int, opts ...Option) Limiter {
 	config := buildConfig(opts)
 	l := &limiter{
 		perRequest: time.Second / time.Duration(rate),
@@ -103,17 +103,17 @@ func New(rate int, opts ...option) Limiter {
 	return l
 }
 
-// WithClock returns an option for ratelimit.New that provides an alternate
+// WithClock returns an Option for ratelimit.New that provides an alternate
 // Clock implementation, typically a mock Clock for testing.
-func WithClock(clock Clock) option {
+func WithClock(clock Clock) Option {
 	return func(c *config) {
 		c.clock = clock
 	}
 }
 
-// WithoutSlack is an option for ratelimit.New that initializes the limiter
+// WithoutSlack is an Option for ratelimit.New that initializes the limiter
 // without any initial tolerance for bursts of traffic.
-var WithoutSlack option = func(c *config) {
+var WithoutSlack Option = func(c *config) {
 	c.maxSlack = 0
 }
 


### PR DESCRIPTION
Prefactor for #43

It's annoying to use if it's private & it's the recommended way
per the style guide.

A follow up diff will convert the Option to interface.