### PR TITLE
Check for precise values in tests, instead of a delta.

### DIFF
--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -72,7 +72,7 @@ func (r *runnerImpl) startTaking(rls ...ratelimit.Limiter) {
 func (r *runnerImpl) assertCountAt(d time.Duration, count int) {
 	r.wg.Add(1)
 	r.afterFunc(d, func() {
-		assert.InDelta(r.t, count, r.count.Load(), 10, "count within rate limit")
+		assert.Equal(r.t, int32(count), r.count.Load(), "count not as expected")
 		r.wg.Done()
 	})
 }


### PR DESCRIPTION
Recent work (test runner) made our tests much more precise - we now
make sure to let all goroutines finish before we start making asserts.

Lets drop the delta in tests - it's no loger needed.

This will make our future tests, with various slack options,
more precise.