### PR TITLE
Refactor: separate inteface from the implementations

### DIFF
--- a/limiter_atomic.go
+++ b/limiter_atomic.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016,2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ratelimit // import "go.uber.org/ratelimit"
+
+import (
+	"time"
+
+	"sync/atomic"
+	"unsafe"
+)
+
+type state struct {
+	last     time.Time
+	sleepFor time.Duration
+}
+
+type atomicLimiter struct {
+	state unsafe.Pointer
+	//lint:ignore U1000 Padding is unused but it is crucial to maintain performance
+	// of this rate limiter in case of collocation with other frequently accessed memory.
+	padding [56]byte // cache line size - state pointer size = 64 - 8; created to avoid false sharing.
+
+	perRequest time.Duration
+	maxSlack   time.Duration
+	clock      Clock
+}
+
+// newAtomicBased returns a new atomic based limiter.
+func newAtomicBased(rate int, opts ...Option) *atomicLimiter {
+	config := buildConfig(opts)
+	l := &atomicLimiter{
+		perRequest: time.Second / time.Duration(rate),
+		maxSlack:   -1 * config.maxSlack * time.Second / time.Duration(rate),
+		clock:      config.clock,
+	}
+
+	initialState := state{
+		last:     time.Time{},
+		sleepFor: 0,
+	}
+	atomic.StorePointer(&l.state, unsafe.Pointer(&initialState))
+	return l
+}
+
+// Take blocks to ensure that the time spent between multiple
+// Take calls is on average time.Second/rate.
+func (t *atomicLimiter) Take() time.Time {
+	newState := state{}
+	taken := false
+	for !taken {
+		now := t.clock.Now()
+
+		previousStatePointer := atomic.LoadPointer(&t.state)
+		oldState := (*state)(previousStatePointer)
+
+		newState = state{}
+		newState.last = now
+
+		// If this is our first request, then we allow it.
+		if oldState.last.IsZero() {
+			taken = atomic.CompareAndSwapPointer(&t.state, previousStatePointer, unsafe.Pointer(&newState))
+			continue
+		}
+
+		// sleepFor calculates how much time we should sleep based on
+		// the perRequest budget and how long the last request took.
+		// Since the request may take longer than the budget, this number
+		// can get negative, and is summed across requests.
+		newState.sleepFor += t.perRequest - now.Sub(oldState.last)
+		// We shouldn't allow sleepFor to get too negative, since it would mean that
+		// a service that slowed down a lot for a short period of time would get
+		// a much higher RPS following that.
+		if newState.sleepFor < t.maxSlack {
+			newState.sleepFor = t.maxSlack
+		}
+		if newState.sleepFor > 0 {
+			newState.last = newState.last.Add(newState.sleepFor)
+		}
+		taken = atomic.CompareAndSwapPointer(&t.state, previousStatePointer, unsafe.Pointer(&newState))
+	}
+	t.clock.Sleep(newState.sleepFor)
+	return newState.last
+}

--- a/limiter_mutexbased.go
+++ b/limiter_mutexbased.go
@@ -1,4 +1,24 @@
-package ratelimit
+// Copyright (c) 2016,2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ratelimit // import "go.uber.org/ratelimit"
 
 import (
 	"sync"
@@ -14,8 +34,8 @@ type mutexLimiter struct {
 	clock      Clock
 }
 
-// New returns a Limiter that will limit to the given RPS.
-func newMutexBased(rate int, opts ...Option) Limiter {
+// newMutexBased returns a new atomic based limiter.
+func newMutexBased(rate int, opts ...Option) *mutexLimiter {
 	config := buildConfig(opts)
 	l := &mutexLimiter{
 		perRequest: time.Second / time.Duration(rate),

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2016,2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,9 +23,6 @@ package ratelimit // import "go.uber.org/ratelimit"
 import (
 	"time"
 
-	"sync/atomic"
-	"unsafe"
-
 	"github.com/andres-erbsen/clock"
 )
 
@@ -48,26 +45,15 @@ type Clock interface {
 	Sleep(time.Duration)
 }
 
-type state struct {
-	last     time.Time
-	sleepFor time.Duration
-}
-
-type limiter struct {
-	state unsafe.Pointer
-	//lint:ignore U1000 Padding is unused but it is crucial to maintain performance
-	// of this rate limiter in case of collocation with other frequently accessed memory.
-	padding [56]byte // cache line size - state pointer size = 64 - 8; created to avoid false sharing.
-
-	perRequest time.Duration
-	maxSlack   time.Duration
-	clock      Clock
-}
-
 // config configures a limiter.
 type config struct {
 	maxSlack time.Duration
 	clock    Clock
+}
+
+// New returns a Limiter that will limit to the given RPS.
+func New(rate int, opts ...Option) Limiter {
+	return newAtomicBased(rate, opts...)
 }
 
 // buildConfig combines defaults with options.
@@ -86,23 +72,6 @@ func buildConfig(opts []Option) config {
 // Option configures a Limiter.
 type Option interface {
 	apply(*config)
-}
-
-// New returns a Limiter that will limit to the given RPS.
-func New(rate int, opts ...Option) Limiter {
-	config := buildConfig(opts)
-	l := &limiter{
-		perRequest: time.Second / time.Duration(rate),
-		maxSlack:   -1 * config.maxSlack * time.Second / time.Duration(rate),
-		clock:      config.clock,
-	}
-
-	initialState := state{
-		last:     time.Time{},
-		sleepFor: 0,
-	}
-	atomic.StorePointer(&l.state, unsafe.Pointer(&initialState))
-	return l
 }
 
 type clockOption struct {
@@ -128,46 +97,6 @@ func (o slackOption) apply(c *config) {
 // WithoutSlack is an Option for ratelimit.New that initializes the limiter
 // without any initial tolerance for bursts of traffic.
 var WithoutSlack Option = slackOption(0)
-
-// Take blocks to ensure that the time spent between multiple
-// Take calls is on average time.Second/rate.
-func (t *limiter) Take() time.Time {
-	newState := state{}
-	taken := false
-	for !taken {
-		now := t.clock.Now()
-
-		previousStatePointer := atomic.LoadPointer(&t.state)
-		oldState := (*state)(previousStatePointer)
-
-		newState = state{}
-		newState.last = now
-
-		// If this is our first request, then we allow it.
-		if oldState.last.IsZero() {
-			taken = atomic.CompareAndSwapPointer(&t.state, previousStatePointer, unsafe.Pointer(&newState))
-			continue
-		}
-
-		// sleepFor calculates how much time we should sleep based on
-		// the perRequest budget and how long the last request took.
-		// Since the request may take longer than the budget, this number
-		// can get negative, and is summed across requests.
-		newState.sleepFor += t.perRequest - now.Sub(oldState.last)
-		// We shouldn't allow sleepFor to get too negative, since it would mean that
-		// a service that slowed down a lot for a short period of time would get
-		// a much higher RPS following that.
-		if newState.sleepFor < t.maxSlack {
-			newState.sleepFor = t.maxSlack
-		}
-		if newState.sleepFor > 0 {
-			newState.last = newState.last.Add(newState.sleepFor)
-		}
-		taken = atomic.CompareAndSwapPointer(&t.state, previousStatePointer, unsafe.Pointer(&newState))
-	}
-	t.clock.Sleep(newState.sleepFor)
-	return newState.last
-}
 
 type unlimited struct{}
 


### PR DESCRIPTION
Just a tiny cleanup - no functional changes:
- keep the "shared/abstract" (config, interface) in ratelimit.go
- move the atomic implementation specific bits into "limiter_atomic"
- move "mutexbased" into "limiter_mutexbased" so that the naming
  is more consistent

Since I'm here I'm also updating the licenses.

The goal is to make reasoning/futher modifications easier, which
changes touching specific implementations only touching specific
implementation files.