### PR TITLE
Fix a bug in coverage github action

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -28,9 +28,7 @@ jobs:
         run: go mod download
 
       - name: Make coverage
-        if: matrix.latest
         run: make cover
 
       - name: Upload coverage to codecov.io
-        if: matrix.latest
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Spotted in #49, which still complains about base branch still
not being there, despite #49 being an attempted fix.

Looking at https://github.com/uber-go/ratelimit/runs/1550973276
explained the issue - we're still not pushing the coverage.