### PR TITLE
Run benchmarks on push to master

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,31 @@
+name: benchmark
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Load cached dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Benchmark
+        run: make bench


### PR DESCRIPTION
This is so that we have history of the performance before
we start making changes.

Ideally, we'd have some kind of human readable display/numbers,
but that's another step.

Opting for running this only on push to master because those tests
are heave & take minutes - I don't think there's a need to run
them on every push. Might be wrong, but lets see how this goes.