### PR TITLE
Fix irregularity in benchmark

### DIFF
--- a/ratelimit_bench_test.go
+++ b/ratelimit_bench_test.go
@@ -29,7 +29,7 @@ func BenchmarkRateLimiter(b *testing.B) {
 			for ng := 512; ng < 1024; ng += 32 {
 				runner(b, name, procs, ng, limiter, count)
 			}
-			for ng := 1024; ng < 2048; ng += 8 {
+			for ng := 1024; ng < 2048; ng += 64 {
 				runner(b, name, procs, ng, limiter, count)
 			}
 			for ng := 2048; ng < 4096; ng += 128 {


### PR DESCRIPTION
The benchmark exetutes the test from 1 to 65k goroutines. Not to take
forever it appropriately uses steps as the number of goroutines grows.

The bucked between 1024 and 2048 has an irregularly low step.
I suspect this is because it's where the atomic limiter becomes
much slower.
However, the small step is not really necessary to show the degredation,
it'll be clearly visible anyway.

Let's make the steps bigger, and make the benchmark run faster.