### PR TITLE
Make linting fail on warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ gofmt:
 
 .PHONY: golint
 golint: bin/golint
-	@$(GOBIN)/golint ./...
+	@$(GOBIN)/golint -set_exit_status ./...
 
 .PHONY: lint
 lint: gofmt golint staticcheck

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -83,7 +83,7 @@ func buildConfig(opts []Option) config {
 	return c
 }
 
-// option configures a Limiter.
+// Option configures a Limiter.
 type Option interface {
 	apply(*config)
 }


### PR DESCRIPTION
Currently, the linter just prints a warning if you run the linter,
but returns 0, so linting passed on CI.

After this change we'll start failing for linter warnings,
which is what I believe we want.