### PR TITLE
Run tests on all (two) implementations

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,32 @@
+package ratelimit_test
+
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/ratelimit"
+)
+
+func Example() {
+	rl := ratelimit.New(100) // per second
+
+	prev := time.Now()
+	for i := 0; i < 10; i++ {
+		now := rl.Take()
+		if i > 0 {
+			fmt.Println(i, now.Sub(prev))
+		}
+		prev = now
+	}
+
+	// Output:
+	// 1 10ms
+	// 2 10ms
+	// 3 10ms
+	// 4 10ms
+	// 5 10ms
+	// 6 10ms
+	// 7 10ms
+	// 8 10ms
+	// 9 10ms
+}

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -60,9 +60,10 @@ func runTest(t *testing.T, fn func(testRunner)) {
 	for _, tt := range implementations {
 		t.Run(tt.name, func(t *testing.T) {
 			r := runnerImpl{
-				t:      t,
-				clock:  clock.NewMock(),
-				doneCh: make(chan struct{}),
+				t:           t,
+				clock:       clock.NewMock(),
+				constructor: tt.constructor,
+				doneCh:      make(chan struct{}),
 			}
 			defer close(r.doneCh)
 			defer r.wg.Wait()
@@ -76,7 +77,7 @@ func runTest(t *testing.T, fn func(testRunner)) {
 // createLimiter builds a limiter with given options.
 func (r *runnerImpl) createLimiter(rate int, opts ...Option) Limiter {
 	opts = append(opts, WithClock(r.clock))
-	return New(rate, opts...)
+	return r.constructor(rate, opts...)
 }
 
 // startTaking tries to Take() on passed in limiters in a loop/goroutine.

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -1,4 +1,4 @@
-package ratelimit_test
+package ratelimit
 
 import (
 	"fmt"
@@ -7,17 +7,16 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
-	"go.uber.org/ratelimit"
 
 	"github.com/andres-erbsen/clock"
 	"github.com/stretchr/testify/assert"
 )
 
-type runner interface {
+type testRunner interface {
 	// createLimiter builds a limiter with given options.
-	createLimiter(int, ...ratelimit.Option) ratelimit.Limiter
+	createLimiter(int, ...Option) Limiter
 	// startTaking tries to Take() on passed in limiters in a loop/goroutine.
-	startTaking(rls ...ratelimit.Limiter)
+	startTaking(rls ...Limiter)
 	// assertCountAt asserts the limiters have Taken() a number of times at the given time.
 	// It's a thin wrapper around afterFunc to reduce boilerplate code.
 	assertCountAt(d time.Duration, count int)
@@ -29,8 +28,9 @@ type runner interface {
 type runnerImpl struct {
 	t *testing.T
 
-	clock *clock.Mock
-	count atomic.Int32
+	clock       *clock.Mock
+	constructor func(int, ...Option) Limiter
+	count       atomic.Int32
 	// maxDuration is the time we need to move into the future for a test.
 	// It's populated automatically based on assertCountAt/afterFunc.
 	maxDuration time.Duration
@@ -38,27 +38,49 @@ type runnerImpl struct {
 	wg          sync.WaitGroup
 }
 
-func runTest(t *testing.T, fn func(runner)) {
-	r := runnerImpl{
-		t:      t,
-		clock:  clock.NewMock(),
-		doneCh: make(chan struct{}),
+func runTest(t *testing.T, fn func(testRunner)) {
+	implementations := []struct {
+		name        string
+		constructor func(int, ...Option) Limiter
+	}{
+		{
+			name: "mutex",
+			constructor: func(rate int, opts ...Option) Limiter {
+				return newMutexBased(rate, opts...)
+			},
+		},
+		{
+			name: "atomic",
+			constructor: func(rate int, opts ...Option) Limiter {
+				return newAtomicBased(rate, opts...)
+			},
+		},
 	}
-	defer close(r.doneCh)
-	defer r.wg.Wait()
 
-	fn(&r)
-	r.clock.Add(r.maxDuration)
+	for _, tt := range implementations {
+		t.Run(tt.name, func(t *testing.T) {
+			r := runnerImpl{
+				t:      t,
+				clock:  clock.NewMock(),
+				doneCh: make(chan struct{}),
+			}
+			defer close(r.doneCh)
+			defer r.wg.Wait()
+
+			fn(&r)
+			r.clock.Add(r.maxDuration)
+		})
+	}
 }
 
 // createLimiter builds a limiter with given options.
-func (r *runnerImpl) createLimiter(rate int, opts ...ratelimit.Option) ratelimit.Limiter {
-	opts = append(opts, ratelimit.WithClock(r.clock))
-	return ratelimit.New(rate, opts...)
+func (r *runnerImpl) createLimiter(rate int, opts ...Option) Limiter {
+	opts = append(opts, WithClock(r.clock))
+	return New(rate, opts...)
 }
 
 // startTaking tries to Take() on passed in limiters in a loop/goroutine.
-func (r *runnerImpl) startTaking(rls ...ratelimit.Limiter) {
+func (r *runnerImpl) startTaking(rls ...Limiter) {
 	r.goWait(func() {
 		for {
 			for _, rl := range rls {
@@ -111,7 +133,7 @@ func (r *runnerImpl) goWait(fn func()) {
 }
 
 func Example() {
-	rl := ratelimit.New(100) // per second
+	rl := New(100) // per second
 
 	prev := time.Now()
 	for i := 0; i < 10; i++ {
@@ -136,7 +158,7 @@ func Example() {
 
 func TestUnlimited(t *testing.T) {
 	now := time.Now()
-	rl := ratelimit.NewUnlimited()
+	rl := NewUnlimited()
 	for i := 0; i < 1000; i++ {
 		rl.Take()
 	}
@@ -144,8 +166,8 @@ func TestUnlimited(t *testing.T) {
 }
 
 func TestRateLimiter(t *testing.T) {
-	runTest(t, func(r runner) {
-		rl := r.createLimiter(100, ratelimit.WithoutSlack)
+	runTest(t, func(r testRunner) {
+		rl := r.createLimiter(100, WithoutSlack)
 
 		// Create copious counts concurrently.
 		r.startTaking(rl)
@@ -160,14 +182,14 @@ func TestRateLimiter(t *testing.T) {
 }
 
 func TestDelayedRateLimiter(t *testing.T) {
-	runTest(t, func(r runner) {
-		slow := r.createLimiter(10, ratelimit.WithoutSlack)
-		fast := r.createLimiter(100, ratelimit.WithoutSlack)
+	runTest(t, func(r testRunner) {
+		slow := r.createLimiter(10, WithoutSlack)
+		fast := r.createLimiter(100, WithoutSlack)
 
 		// Run a slow startTaking
 		r.startTaking(slow, fast)
 
-		// Accumulate slack for 10 seconds,
+		// Accumulate slack for 20 seconds,
 		r.afterFunc(20*time.Second, func() {
 			// Then start working.
 			r.startTaking(fast)
@@ -181,8 +203,8 @@ func TestDelayedRateLimiter(t *testing.T) {
 }
 
 func TestPer(t *testing.T) {
-	runTest(t, func(r runner) {
-		rl := r.createLimiter(7, ratelimit.WithoutSlack, ratelimit.Per(time.Minute))
+	runTest(t, func(r testRunner) {
+		rl := r.createLimiter(7, WithoutSlack, Per(time.Minute))
 
 		r.startTaking(rl)
 		r.startTaking(rl)

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -1,7 +1,6 @@
 package ratelimit
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -39,7 +38,7 @@ type runnerImpl struct {
 }
 
 func runTest(t *testing.T, fn func(testRunner)) {
-	implementations := []struct {
+	impls := []struct {
 		name        string
 		constructor func(int, ...Option) Limiter
 	}{
@@ -57,7 +56,7 @@ func runTest(t *testing.T, fn func(testRunner)) {
 		},
 	}
 
-	for _, tt := range implementations {
+	for _, tt := range impls {
 		t.Run(tt.name, func(t *testing.T) {
 			r := runnerImpl{
 				t:           t,
@@ -131,30 +130,6 @@ func (r *runnerImpl) goWait(fn func()) {
 		fn()
 	}()
 	wg.Wait()
-}
-
-func Example() {
-	rl := New(100) // per second
-
-	prev := time.Now()
-	for i := 0; i < 10; i++ {
-		now := rl.Take()
-		if i > 0 {
-			fmt.Println(i, now.Sub(prev))
-		}
-		prev = now
-	}
-
-	// Output:
-	// 1 10ms
-	// 2 10ms
-	// 3 10ms
-	// 4 10ms
-	// 5 10ms
-	// 6 10ms
-	// 7 10ms
-	// 8 10ms
-	// 9 10ms
 }
 
 func TestUnlimited(t *testing.T) {


### PR DESCRIPTION
The test runner will simply execute all tests on all implementations.

This is so that we can:
- make sure both implementations are equivalent
- start adding more implementations
- have proper test coverage, yay.

The diff is slightly bigger than the actual changes:
- I'm modifying the tests to run in the same package as the code,
  so that I have access to each of the implementations.
- I'm renaming `runner` to `testRunner` since benchmark defines it's
  own runner.

I considered somehow keeping the `ratelimit_test` package,
and also having a separate `ratelimit` tests to just test
implementations  but that feels too complicated for the benefit - lets
keep it simple and just have a single set of tests.

We could probably also make the benchmark tests re-use the same test runner,
but that's a separate follow up.