### PR TITLE
Allow configuring custom slack

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -100,6 +100,13 @@ func (o slackOption) apply(c *config) {
 // previously "unspent" requests for future bursts of traffic.
 var WithoutSlack Option = slackOption(0)
 
+// WithSlack configures custom slack.
+// Slack allows the limiter to accumulate "unspent" requests
+// for future bursts of traffic.
+func WithSlack(slack int) Option {
+	return slackOption(slack)
+}
+
 type perOption time.Duration
 
 func (p perOption) apply(c *config) {

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -202,7 +202,6 @@ func TestSlack(t *testing.T) {
 	//   - faster limiter running for 1 second
 	//   - slack accumulated by the faster limiter during the two seconds.
 	//     it was blocked by slower limiter.
-
 	tests := []struct {
 		msg  string
 		opt  []Option
@@ -214,10 +213,48 @@ func TestSlack(t *testing.T) {
 			want: 130,
 		},
 		{
+			msg: "slack of 10, like default",
+			opt: []Option{WithSlack(10)},
+			// 2*10 + 1*100 + 1*10 (slack)
+			want: 130,
+		},
+		{
+			msg: "slack of 20",
+			opt: []Option{WithSlack(20)},
+			// 2*10 + 1*100 + 1*20 (slack)
+			want: 140,
+		},
+		{
+			// Note this is bigger then the rate of the limiter.
+			msg: "slack of 150",
+			opt: []Option{WithSlack(150)},
+			// 2*10 + 1*100 + 1*150 (slack)
+			want: 270,
+		},
+		{
 			msg: "no option, defaults to 10, with per",
 			// 2*(10*2) + 1*(100*2) + 1*10 (slack)
 			opt:  []Option{Per(500 * time.Millisecond)},
 			want: 230,
+		},
+		{
+			msg: "slack of 10, like default, with per",
+			opt: []Option{WithSlack(10), Per(500 * time.Millisecond)},
+			// 2*(10*2) + 1*(100*2) + 1*10 (slack)
+			want: 230,
+		},
+		{
+			msg: "slack of 20, with per",
+			opt: []Option{WithSlack(20), Per(500 * time.Millisecond)},
+			// 2*(10*2) + 1*(100*2) + 1*20 (slack)
+			want: 240,
+		},
+		{
+			// Note this is bigger then the rate of the limiter.
+			msg: "slack of 150, with per",
+			opt: []Option{WithSlack(150), Per(500 * time.Millisecond)},
+			// 2*(10*2) + 1*(100*2) + 1*150 (slack)
+			want: 370,
 		},
 	}
 
@@ -240,5 +277,4 @@ func TestSlack(t *testing.T) {
 			})
 		})
 	}
-
 }


### PR DESCRIPTION
Resolves #20

This is to allow people to configure custom slack - we previously
defaulted to 10, and only allowed to disable it.

The only tricky part about this is handling "per" correctly - adding
a bunch of test cases to cover it.

The tests are large, but when I tried to generate them dynamically
(the same test cases 2*, for both with-per and without-per) it became
even harder to read.
