### PR TITLE
Fix docstring on WithoutSlack Option

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -96,8 +96,8 @@ func (o slackOption) apply(c *config) {
 	c.maxSlack = time.Duration(o)
 }
 
-// WithoutSlack is an Option for ratelimit.New that initializes the limiter
-// without any initial tolerance for bursts of traffic.
+// WithoutSlack configures the limiter to be strict and not to accumulate
+// previously "unspent" requests for future bursts of traffic.
 var WithoutSlack Option = slackOption(0)
 
 type perOption time.Duration


### PR DESCRIPTION
The previous description didn't really make sense.
This one hopefully does - at least in my head.
Not sure if we should be adding a full description of slack,
but probably not in this docstring.