### PR TITLE
Fix slack ignoring "Per" option

### DIFF
--- a/limiter_atomic.go
+++ b/limiter_atomic.go
@@ -45,10 +45,13 @@ type atomicLimiter struct {
 
 // newAtomicBased returns a new atomic based limiter.
 func newAtomicBased(rate int, opts ...Option) *atomicLimiter {
+	// TODO consider moving config building to the implementation
+	// independent code.
 	config := buildConfig(opts)
+	perRequest := config.per / time.Duration(rate)
 	l := &atomicLimiter{
-		perRequest: config.per / time.Duration(rate),
-		maxSlack:   -1 * config.maxSlack * time.Second / time.Duration(rate),
+		perRequest: perRequest,
+		maxSlack:   -1 * time.Duration(config.slack) * perRequest,
 		clock:      config.clock,
 	}
 

--- a/limiter_mutexbased.go
+++ b/limiter_mutexbased.go
@@ -36,10 +36,13 @@ type mutexLimiter struct {
 
 // newMutexBased returns a new atomic based limiter.
 func newMutexBased(rate int, opts ...Option) *mutexLimiter {
+	// TODO consider moving config building to the implementation
+	// independent code.
 	config := buildConfig(opts)
+	perRequest := config.per / time.Duration(rate)
 	l := &mutexLimiter{
-		perRequest: config.per / time.Duration(rate),
-		maxSlack:   -1 * config.maxSlack * time.Second / time.Duration(rate),
+		perRequest: perRequest,
+		maxSlack:   -1 * time.Duration(config.slack) * perRequest,
 		clock:      config.clock,
 	}
 	return l

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -47,9 +47,9 @@ type Clock interface {
 
 // config configures a limiter.
 type config struct {
-	clock    Clock
-	maxSlack time.Duration
-	per      time.Duration
+	clock Clock
+	slack int
+	per   time.Duration
 }
 
 // New returns a Limiter that will limit to the given RPS.
@@ -60,9 +60,9 @@ func New(rate int, opts ...Option) Limiter {
 // buildConfig combines defaults with options.
 func buildConfig(opts []Option) config {
 	c := config{
-		clock:    clock.New(),
-		maxSlack: 10,
-		per:      time.Second,
+		clock: clock.New(),
+		slack: 10,
+		per:   time.Second,
 	}
 
 	for _, opt := range opts {
@@ -93,7 +93,7 @@ func WithClock(clock Clock) Option {
 type slackOption int
 
 func (o slackOption) apply(c *config) {
-	c.maxSlack = time.Duration(o)
+	c.slack = int(o)
 }
 
 // WithoutSlack is an Option for ratelimit.New that initializes the limiter


### PR DESCRIPTION
This is a split off #64 to make #64 smaller/easier.

I believe out current treatment of the default (10) slack doesn't
work very well with Per option.

We configure the limiter with an limit:
- `Limiter(10)` - means, allow 10 requests per second, with 10 requests
  slack - "slack period" is 1 second

However, if we do:
- `Limiter(10, Per(time.Minute))` we get - 10 requests per minute,
  but the slack is still 10 *per second*, meaning the slack period is
  stil 10 second - effectively 1 request.
I believe this is confusing, because with "slack of 10", I'd expect
a 1 minute "slack period".

After this change:
- `Limiter(10, Per(time.Minute))` we get - 10 requests per minute,
  and a slack of 10 requests - so, slack period is 1 minute.

We're basically making it so that both "rate" and "slack" are expressed
in the same unit (ints) and that "Per" applies to both of them.

Note this is currently of minor impact since we're hardcoding the
slack as 10. This will become way more painful/complicated with #64.