### PR TITLE
Start testing on Go1.16, deprecate 1.14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,9 @@ jobs:
 
     strategy:
       matrix:
-        go: ["1.14.x", "1.15.x"]
+        go: ["1.15.x", "1.16.x"]
         include:
-        - go: 1.15.x
+        - go: 1.16.x
           latest: true
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/ratelimit
 
-go 1.16
+go 1.14
 
 require (
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/ratelimit
 
-go 1.14
+go 1.16
 
 require (
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129


### PR DESCRIPTION
Per https://golang.org/ref/mod#go-mod-file-go it doesn't look like
updating the go directive in go.mod will have a major impact on us,
I don't think we depend on any particular features.

In fact, https://blog.ksub.org/bytes/2019/09/15/go.mods-go-directive/
seems to suggest it'll have no impact whatsoever as long we we
don't start uusing 1.15 or 1.16 features.

So lets just update it to be up to date (?)