### PR TITLE
Correct the comments of Take functions

### DIFF
--- a/limiter_atomic.go
+++ b/limiter_atomic.go
@@ -64,7 +64,7 @@ func newAtomicBased(rate int, opts ...Option) *atomicLimiter {
 }
 
 // Take blocks to ensure that the time spent between multiple
-// Take calls is on average time.Second/rate.
+// Take calls is on average per/rate.
 func (t *atomicLimiter) Take() time.Time {
 	var (
 		newState state

--- a/limiter_mutexbased.go
+++ b/limiter_mutexbased.go
@@ -49,7 +49,7 @@ func newMutexBased(rate int, opts ...Option) *mutexLimiter {
 }
 
 // Take blocks to ensure that the time spent between multiple
-// Take calls is on average time.Second/rate.
+// Take calls is on average per/rate.
 func (t *mutexLimiter) Take() time.Time {
 	t.Lock()
 	defer t.Unlock()


### PR DESCRIPTION
As it can be configured by `Per` function, the `per` no longer always defaults to `time.Second`.