### PR TITLE
Only benchmark on the latest Go version

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -10,22 +10,10 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go }}
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Load cached dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-
-      - name: Download dependencies
-        run: go mod download
-
+          check-latest: true
+          cache: true
       - name: Benchmark
         run: make bench


### PR DESCRIPTION
See  https://github.com/uber-go/ratelimit/issues/86#issuecomment-1146895304

Also:
- update to checkoutv3 (why not)
- use setup-go action to both:
  - pick up the lastest go version
  - do appropriate caching