### PR TITLE
Use actively maintained clock library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module go.uber.org/ratelimit
 go 1.18
 
 require (
-	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129
+	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/atomic v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
-github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -23,7 +23,7 @@ package ratelimit // import "go.uber.org/ratelimit"
 import (
 	"time"
 
-	"github.com/andres-erbsen/clock"
+	"github.com/benbjohnson/clock"
 )
 
 // Note: This file is inspired by:

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -7,7 +7,7 @@ import (
 
 	"go.uber.org/atomic"
 
-	"github.com/andres-erbsen/clock"
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
 It looks like our clock mocking library is supper old and archived by author.
 It can be a cause of our test instabilities.
 This PR replaces it with drop-in replacement that is actively maintained.