### PR TITLE
Add a test verifying initial startup sequence

### DIFF
--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -22,6 +22,8 @@ type testRunner interface {
 	// afterFunc executes a func at a given time.
 	// not using clock.AfterFunc because andres-erbsen/clock misses a nap there.
 	afterFunc(d time.Duration, fn func())
+	// some tests want raw access to the clock.
+	getClock() *clock.Mock
 }
 
 type runnerImpl struct {
@@ -87,6 +89,10 @@ func runTest(t *testing.T, fn func(testRunner)) {
 func (r *runnerImpl) createLimiter(rate int, opts ...Option) Limiter {
 	opts = append(opts, WithClock(r.clock))
 	return r.constructor(rate, opts...)
+}
+
+func (r *runnerImpl) getClock() *clock.Mock {
+	return r.clock
 }
 
 // startTaking tries to Take() on passed in limiters in a loop/goroutine.
@@ -196,6 +202,66 @@ func TestPer(t *testing.T) {
 		r.assertCountAt(1*time.Minute, 8)
 		r.assertCountAt(2*time.Minute, 15)
 	})
+}
+
+// TestInitial verifies that the initial sequence is scheduled as expected.
+func TestInitial(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		msg  string
+		opts []Option
+	}{
+		{
+			msg: "With Slack",
+		},
+		{
+			msg:  "Without Slack",
+			opts: []Option{WithoutSlack},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			runTest(t, func(r testRunner) {
+				rl := r.createLimiter(10, tt.opts...)
+
+				var (
+					clk            = r.getClock()
+					prev time.Time = clk.Now()
+
+					results         []time.Duration
+					startWg, doneWg sync.WaitGroup
+				)
+				startWg.Add(3)
+				doneWg.Add(3)
+
+				for i := 0; i < 3; i++ {
+					go func() {
+						startWg.Done()
+						ts := rl.Take()
+						// Below changes while "racy" should be synchronized by the limiter.
+						results = append(results, ts.Sub(prev))
+						prev = ts
+						doneWg.Done()
+					}()
+				}
+
+				startWg.Wait()
+				clk.Add(time.Second)
+				doneWg.Wait()
+
+				assert.Equal(t,
+					[]time.Duration{
+						0,
+						time.Millisecond * 100,
+						time.Millisecond * 100,
+					},
+					results,
+					"bad timestamps for inital takes",
+				)
+			})
+		})
+	}
 }
 
 func TestSlack(t *testing.T) {


### PR DESCRIPTION
See https://github.com/uber-go/ratelimit/pull/95#discussion_r915251700

From that discussion I wasn't sure whether the proposed the initial
startup sequence of the limiter - i.e. whether at startup we always
block, or always allow.

Since we didn't seem to have that codified (perhaps apart from the
`example_test.go`) this PR adds a test to verify this.

This is still slightly (2/1000) flaky, but I think that's good enough
to add this in - should be valuable anyway.