### PR TITLE
Use `atomic.Pointer` type to remove unsafe package usage directly

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,21 +22,37 @@ package ratelimit // import "go.uber.org/ratelimit"
 
 import (
 	"time"
+
+	"github.com/benbjohnson/clock"
 )
 
-// Note: This file is inspired by:
-// https://github.com/prashantv/go-bench/blob/master/ratelimit
-
-// Limiter is used to rate-limit some process, possibly across goroutines.
-// The process is expected to call Take() before every iteration, which
-// may block to throttle the goroutine.
-type Limiter interface {
-	// Take should block to make sure that the RPS is met.
-	Take() time.Time
+// Clock is the minimum necessary interface to instantiate a rate limiter with
+// a clock or mock clock, compatible with clocks created using
+// github.com/andres-erbsen/clock.
+type Clock interface {
+	Now() time.Time
+	Sleep(time.Duration)
 }
 
-// New returns a Limiter that will limit to the given RPS.
-func New(rate int, opts ...Option) Limiter {
-	var config = buildConfig(opts)
-	return newAtomicInt64Based(rate, config)
+// buildConfig combines defaults with options.
+func buildConfig(opts []Option) (c config) {
+	c.init()
+	for _, opt := range opts {
+		opt.apply(&c)
+	}
+	return
+}
+
+// config configures a limiter.
+type config struct {
+	clock Clock
+	slack int
+	per   time.Duration
+}
+
+// init initialize a new config with default values.
+func (c *config) init() {
+	c.clock = clock.New()
+	c.slack = 10
+	c.per = time.Second
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/ratelimit
 
-go 1.18
+go 1.20
 
 require (
 	github.com/benbjohnson/clock v1.3.0

--- a/limiter_atomic.go
+++ b/limiter_atomic.go
@@ -44,22 +44,19 @@ type state struct {
 }
 
 // newAtomicBased returns a new atomic based limiter.
-func newAtomicBased(rate int, opts ...Option) *atomicLimiter {
+func newAtomicBased(rate int, conf config) *atomicLimiter {
 	var al atomicLimiter
-	al.init(rate, opts...)
+	al.init(rate, conf)
 	return &al
 }
 
 // init initialize a new atomic based limiter.
-func (t *atomicLimiter) init(rate int, opts ...Option) {
-	// TODO consider moving config building to the implementation
-	// independent code.
-	var config = buildConfig(opts)
-	var perRequest = config.per / time.Duration(rate)
+func (t *atomicLimiter) init(rate int, conf config) {
+	var perRequest = conf.per / time.Duration(rate)
 
 	t.perRequest = perRequest
-	t.maxSlack = -1 * time.Duration(config.slack) * perRequest
-	t.clock = config.clock
+	t.maxSlack = -1 * time.Duration(conf.slack) * perRequest
+	t.clock = conf.clock
 }
 
 // Take blocks to ensure that the time spent between multiple

--- a/limiter_atomic_int64.go
+++ b/limiter_atomic_int64.go
@@ -40,22 +40,19 @@ type atomicInt64Limiter struct {
 }
 
 // newAtomicBased returns a new atomic based limiter.
-func newAtomicInt64Based(rate int, opts ...Option) *atomicInt64Limiter {
+func newAtomicInt64Based(rate int, conf config) *atomicInt64Limiter {
 	var al atomicInt64Limiter
-	al.init(rate, opts...)
+	al.init(rate, conf)
 	return &al
 }
 
 // init initialize a new atomic based limiter.
-func (t *atomicInt64Limiter) init(rate int, opts ...Option) {
-	// TODO consider moving config building to the implementation
-	// independent code.
-	var config = buildConfig(opts)
-	var perRequest = config.per / time.Duration(rate)
+func (t *atomicInt64Limiter) init(rate int, conf config) {
+	var perRequest = conf.per / time.Duration(rate)
 
 	t.perRequest = perRequest
-	t.maxSlack = time.Duration(config.slack) * perRequest
-	t.clock = config.clock
+	t.maxSlack = time.Duration(conf.slack) * perRequest
+	t.clock = conf.clock
 }
 
 // Take blocks to ensure that the time spent between multiple

--- a/limiter_mutexbased.go
+++ b/limiter_mutexbased.go
@@ -35,17 +35,19 @@ type mutexLimiter struct {
 }
 
 // newMutexBased returns a new atomic based limiter.
-func newMutexBased(rate int, opts ...Option) *mutexLimiter {
-	// TODO consider moving config building to the implementation
-	// independent code.
-	config := buildConfig(opts)
-	perRequest := config.per / time.Duration(rate)
-	l := &mutexLimiter{
-		perRequest: perRequest,
-		maxSlack:   -1 * time.Duration(config.slack) * perRequest,
-		clock:      config.clock,
-	}
-	return l
+func newMutexBased(rate int, conf config) *mutexLimiter {
+	var ml mutexLimiter
+	ml.init(rate, conf)
+	return &ml
+}
+
+// init initialize a new atomic based limiter.
+func (t *mutexLimiter) init(rate int, conf config) {
+	var perRequest = conf.per / time.Duration(rate)
+
+	t.perRequest = perRequest
+	t.maxSlack = -1 * time.Duration(conf.slack) * perRequest
+	t.clock = conf.clock
 }
 
 // Take blocks to ensure that the time spent between multiple

--- a/option.go
+++ b/option.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016,2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ratelimit // import "go.uber.org/ratelimit"
+
+import (
+	"time"
+)
+
+// Option configures a Limiter.
+type Option interface {
+	apply(*config)
+}
+
+type clockOption struct {
+	clock Clock
+}
+
+func (o clockOption) apply(c *config) {
+	c.clock = o.clock
+}
+
+// WithClock returns an option for ratelimit.New that provides an alternate
+// Clock implementation, typically a mock Clock for testing.
+func WithClock(clock Clock) Option {
+	return clockOption{clock: clock}
+}
+
+type slackOption int
+
+func (o slackOption) apply(c *config) {
+	c.slack = int(o)
+}
+
+// WithoutSlack configures the limiter to be strict and not to accumulate
+// previously "unspent" requests for future bursts of traffic.
+var WithoutSlack Option = slackOption(0)
+
+// WithSlack configures custom slack.
+// Slack allows the limiter to accumulate "unspent" requests
+// for future bursts of traffic.
+func WithSlack(slack int) Option {
+	return slackOption(slack)
+}
+
+type perOption time.Duration
+
+func (p perOption) apply(c *config) {
+	c.per = time.Duration(p)
+}
+
+// Per allows configuring limits for different time windows.
+//
+// The default window is one second, so New(100) produces a one hundred per
+// second (100 Hz) rate limiter.
+//
+// New(2, Per(60*time.Second)) creates a 2 per minute rate limiter.
+func Per(per time.Duration) Option {
+	return perOption(per)
+}
+
+type unlimited struct{}
+
+// NewUnlimited returns a RateLimiter that is not limited.
+func NewUnlimited() Limiter {
+	return unlimited{}
+}
+
+func (unlimited) Take() time.Time {
+	return time.Now()
+}

--- a/ratelimit_bench_test.go
+++ b/ratelimit_bench_test.go
@@ -10,13 +10,14 @@ import (
 )
 
 func BenchmarkRateLimiter(b *testing.B) {
-	count := atomic.NewInt64(0)
+	var count = atomic.NewInt64(0)
+	var config = buildConfig(nil)
 	for _, procs := range []int{1, 4, 8, 16} {
 		runtime.GOMAXPROCS(procs)
 		for name, limiter := range map[string]Limiter{
-			"atomic":       newAtomicBased(b.N * 1000000000000),
-			"atomic_int64": newAtomicInt64Based(b.N * 1000000000000),
-			"mutex":        newMutexBased(b.N * 1000000000000),
+			"atomic":       newAtomicBased(b.N*1000000000000, config),
+			"atomic_int64": newAtomicInt64Based(b.N*1000000000000, config),
+			"mutex":        newMutexBased(b.N*1000000000000, config),
 		} {
 			for ng := 1; ng < 16; ng++ {
 				runner(b, name, procs, ng, limiter, count)

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -47,19 +47,22 @@ func runTest(t *testing.T, fn func(testRunner)) {
 		{
 			name: "mutex",
 			constructor: func(rate int, opts ...Option) Limiter {
-				return newMutexBased(rate, opts...)
+				var conf = buildConfig(opts)
+				return newMutexBased(rate, conf)
 			},
 		},
 		{
 			name: "atomic",
 			constructor: func(rate int, opts ...Option) Limiter {
-				return newAtomicBased(rate, opts...)
+				var conf = buildConfig(opts)
+				return newAtomicBased(rate, conf)
 			},
 		},
 		{
 			name: "atomic_int64",
 			constructor: func(rate int, opts ...Option) Limiter {
-				return newAtomicInt64Based(rate, opts...)
+				var conf = buildConfig(opts)
+				return newAtomicInt64Based(rate, conf)
 			},
 		},
 	}


### PR DESCRIPTION
- Use `atomic.Int64` in `atomicInt64Limiter` type to prevent any mistake non atomic usage
- Move config and option to separate files from `ratelimit.go`
Go is a package base language, So it is better to have many small single responsible files instead a huge multi responsible file.
- moving config building to the implementation independent code
- Fixed some typos