### PR TITLE
Run tests on the latest 2 go versions, update go directive in go.mod

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,9 +16,9 @@ jobs:
 
     strategy:
       matrix:
-        go: ["1.17.x", "1.18.x"]
+        go: ["1.19.x", "1.20.x"]
         include:
-        - go: 1.18.x
+        - go: 1.20.x
           latest: true
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/ratelimit
 
-go 1.18
+go 1.20
 
 require (
 	github.com/benbjohnson/clock v1.3.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/storozhukBM/benchart v1.0.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/perf v0.0.0-20230427221525-d343f6398b76
-	honnef.co/go/tools v0.3.3
+	honnef.co/go/tools v0.4.3
 )
 
 require (

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -115,4 +115,6 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/grpc v0.0.0-20170208002647-2a6bf6142e96/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 honnef.co/go/tools v0.3.3 h1:oDx7VAwstgpYpb3wv0oxiZlxY+foCpRAwY7Vk6XpAgA=
 honnef.co/go/tools v0.3.3/go.mod h1:jzwdWgg7Jdq75wlfblQxO4neNaFFSvgc1tD5Wv8U0Yw=
+honnef.co/go/tools v0.4.3 h1:o/n5/K5gXqk8Gozvs2cnL0F2S1/g1vcGCAx2vETjITw=
+honnef.co/go/tools v0.4.3/go.mod h1:36ZgoUOrqOk1GxwHhyryEkq8FQWkUO2xGuSMhUCcdvA=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=


### PR DESCRIPTION
We support latest two versions, we should be testing on them.

Go directive shouldn't change much, I'm updating it just to be in sync. We're still pre Go 1.21 so this should not affect the users.