### PR TITLE
Fix an issue with maxSlack boundary updates.

### DIFF
--- a/limiter_atomic_int64.go
+++ b/limiter_atomic_int64.go
@@ -21,9 +21,8 @@
 package ratelimit // import "go.uber.org/ratelimit"
 
 import (
-	"time"
-
 	"sync/atomic"
+	"time"
 )
 
 type atomicInt64Limiter struct {
@@ -69,7 +68,7 @@ func (t *atomicInt64Limiter) Take() time.Time {
 		case timeOfNextPermissionIssue == 0 || (t.maxSlack == 0 && now-timeOfNextPermissionIssue > int64(t.perRequest)):
 			// if this is our first call or t.maxSlack == 0 we need to shrink issue time to now
 			newTimeOfNextPermissionIssue = now
-		case t.maxSlack > 0 && now-timeOfNextPermissionIssue > int64(t.maxSlack):
+		case t.maxSlack > 0 && now-timeOfNextPermissionIssue > int64(t.maxSlack)+int64(t.perRequest):
 			// a lot of nanoseconds passed since the last Take call
 			// we will limit max accumulated time to maxSlack
 			newTimeOfNextPermissionIssue = now - int64(t.maxSlack)


### PR DESCRIPTION
Fixes #119
The solution is a copy from #120, but follows the testing framework that we have - I did not want us to have a real `Sleep` in tests.

I'm not exactly thrilled by the testing setup (especially the milliseconds) or the clock itself, but I'm not willing to totally give up on it like #120 proposes.
I also wanted ALL implementations of the ratelimiter to be tested, not just the currently selected.

Might follow up with some testing cleanups and/or clock migration.