### PR TITLE
Fix tests on 32bit archs

### DIFF
--- a/limiter_atomic.go
+++ b/limiter_atomic.go
@@ -44,7 +44,7 @@ type atomicLimiter struct {
 }
 
 // newAtomicBased returns a new atomic based limiter.
-func newAtomicBased(rate int, opts ...Option) *atomicLimiter {
+func newAtomicBased(rate int64, opts ...Option) *atomicLimiter {
 	// TODO consider moving config building to the implementation
 	// independent code.
 	config := buildConfig(opts)

--- a/limiter_atomic_int64.go
+++ b/limiter_atomic_int64.go
@@ -39,7 +39,7 @@ type atomicInt64Limiter struct {
 }
 
 // newAtomicBased returns a new atomic based limiter.
-func newAtomicInt64Based(rate int, opts ...Option) *atomicInt64Limiter {
+func newAtomicInt64Based(rate int64, opts ...Option) *atomicInt64Limiter {
 	// TODO consider moving config building to the implementation
 	// independent code.
 	config := buildConfig(opts)

--- a/limiter_mutexbased.go
+++ b/limiter_mutexbased.go
@@ -35,7 +35,7 @@ type mutexLimiter struct {
 }
 
 // newMutexBased returns a new mutex based limiter.
-func newMutexBased(rate int, opts ...Option) *mutexLimiter {
+func newMutexBased(rate int64, opts ...Option) *mutexLimiter {
 	// TODO consider moving config building to the implementation
 	// independent code.
 	config := buildConfig(opts)

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -53,7 +53,7 @@ type config struct {
 }
 
 // New returns a Limiter that will limit to the given RPS.
-func New(rate int, opts ...Option) Limiter {
+func New(rate int64, opts ...Option) Limiter {
 	return newAtomicInt64Based(rate, opts...)
 }
 

--- a/ratelimit_bench_test.go
+++ b/ratelimit_bench_test.go
@@ -14,9 +14,9 @@ func BenchmarkRateLimiter(b *testing.B) {
 	for _, procs := range []int{1, 4, 8, 16} {
 		runtime.GOMAXPROCS(procs)
 		for name, limiter := range map[string]Limiter{
-			"atomic":       newAtomicBased(b.N * 1000000000000),
-			"atomic_int64": newAtomicInt64Based(b.N * 1000000000000),
-			"mutex":        newMutexBased(b.N * 1000000000000),
+			"atomic":       newAtomicBased(int64(b.N * 1000000000000)),
+			"atomic_int64": newAtomicInt64Based(int64(b.N * 1000000000000)),
+			"mutex":        newMutexBased(int64(b.N * 1000000000000)),
 		} {
 			for ng := 1; ng < 16; ng++ {
 				runner(b, name, procs, ng, limiter, count)

--- a/ratelimit_bench_test.go
+++ b/ratelimit_bench_test.go
@@ -14,9 +14,9 @@ func BenchmarkRateLimiter(b *testing.B) {
 	for _, procs := range []int{1, 4, 8, 16} {
 		runtime.GOMAXPROCS(procs)
 		for name, limiter := range map[string]Limiter{
-			"atomic":       newAtomicBased(int64(b.N * 1000000000000)),
-			"atomic_int64": newAtomicInt64Based(int64(b.N * 1000000000000)),
-			"mutex":        newMutexBased(int64(b.N * 1000000000000)),
+			"atomic":       newAtomicBased(int64(b.N) * int64(1000000000000)),
+			"atomic_int64": newAtomicInt64Based(int64(b.N) * int64(1000000000000)),
+			"mutex":        newMutexBased(int64(b.N) * int64(1000000000000)),
 		} {
 			for ng := 1; ng < 16; ng++ {
 				runner(b, name, procs, ng, limiter, count)

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -13,7 +13,7 @@ import (
 
 type testRunner interface {
 	// createLimiter builds a limiter with given options.
-	createLimiter(int, ...Option) Limiter
+	createLimiter(int64, ...Option) Limiter
 	// takeOnceAfter attempts to Take at a specific time.
 	takeOnceAfter(time.Duration, Limiter)
 	// startTaking tries to Take() on passed in limiters in a loop/goroutine.
@@ -32,7 +32,7 @@ type runnerImpl struct {
 	t *testing.T
 
 	clock       *clock.Mock
-	constructor func(int, ...Option) Limiter
+	constructor func(int64, ...Option) Limiter
 	count       atomic.Int32
 	// maxDuration is the time we need to move into the future for a test.
 	// It's populated automatically based on assertCountAt/afterFunc.
@@ -44,23 +44,23 @@ type runnerImpl struct {
 func runTest(t *testing.T, fn func(testRunner)) {
 	impls := []struct {
 		name        string
-		constructor func(int, ...Option) Limiter
+		constructor func(int64, ...Option) Limiter
 	}{
 		{
 			name: "mutex",
-			constructor: func(rate int, opts ...Option) Limiter {
+			constructor: func(rate int64, opts ...Option) Limiter {
 				return newMutexBased(rate, opts...)
 			},
 		},
 		{
 			name: "atomic",
-			constructor: func(rate int, opts ...Option) Limiter {
+			constructor: func(rate int64, opts ...Option) Limiter {
 				return newAtomicBased(rate, opts...)
 			},
 		},
 		{
 			name: "atomic_int64",
-			constructor: func(rate int, opts ...Option) Limiter {
+			constructor: func(rate int64, opts ...Option) Limiter {
 				return newAtomicInt64Based(rate, opts...)
 			},
 		},
@@ -88,7 +88,7 @@ func runTest(t *testing.T, fn func(testRunner)) {
 }
 
 // createLimiter builds a limiter with given options.
-func (r *runnerImpl) createLimiter(rate int, opts ...Option) Limiter {
+func (r *runnerImpl) createLimiter(rate int64, opts ...Option) Limiter {
 	opts = append(opts, WithClock(r.clock))
 	return r.constructor(rate, opts...)
 }


### PR DESCRIPTION
Hello there,

While packaging your library on Debian I noticed that some tests were failing on 32bit archs because of an integer overflow. This PR fix the tests to ensure correct execution on both 32 and 64bit arch.

It has been tested on Debian architecture and now the package build fine.

- Previous test log: https://ci.debian.net/packages/g/golang-uber-ratelimit/testing/armhf/51192820/
- After the patch: https://ci.debian.net/packages/g/golang-uber-ratelimit/testing/armhf/51214247/

Package details: https://tracker.debian.org/pkg/golang-uber-ratelimit

Cheers,